### PR TITLE
Fixed instructions typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Run the following commands:
 
 #### (training)
 ```
-1. pip install -r requrements.txt
+1. pip install -r requirements.txt
 2. python train.py
 ```
 


### PR DESCRIPTION
Fixed a typo in the instructions that causes an error in installing requirements.